### PR TITLE
Correct license type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/OpenBankProject/Hello-OBP-OAuth1.0a-Node.git"
   },
   "author": "TESOBE Ltd",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/OpenBankProject/Hello-OBP-OAuth1.0a-Node/issues"
   },


### PR DESCRIPTION
To remove "License should be a valid SPDX license expression" console warning